### PR TITLE
Version 0.16.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'scikit-digital-health',
     'c',
-    version: '0.16.0',
+    version: '0.16.1',
     license: 'MIT',
     meson_version: '>=1.1',
 )

--- a/src/skdh/io/base.py
+++ b/src/skdh/io/base.py
@@ -58,7 +58,7 @@ def check_input_file(
                     return kwargs
 
             # check file size if desired
-            if check_size:
+            if check_size and not self.__dict__.get("_multi_read", False):
                 if pfile.stat().st_size < 1000:
                     raise FileSizeError("File is less than 1kb, nothing to read.")
 

--- a/src/skdh/io/base.py
+++ b/src/skdh/io/base.py
@@ -58,7 +58,7 @@ def check_input_file(
                     return kwargs
 
             # check file size if desired
-            if check_size and not self.__dict__.get("_multi_read", False):
+            if check_size and not hasattr(self, "_skip_file_size_check"):
                 if pfile.stat().st_size < 1000:
                     raise FileSizeError("File is less than 1kb, nothing to read.")
 

--- a/src/skdh/io/csv.py
+++ b/src/skdh/io/csv.py
@@ -324,7 +324,7 @@ class ReadCSV(BaseProcess):
         if tz_name is not None:
             # convert, and then remove the timezone so its naive again, but now in local time
             raw[self.time_col_name] = (
-                raw[self.time_col_name].dt.tz_convert(tz_name).dt.tz_localize(None)
+                raw[self.time_col_name].dt.tz_convert(tz_name)
             )
 
         # now handle data gaps and second level timestamps, etc

--- a/src/skdh/io/multireader.py
+++ b/src/skdh/io/multireader.py
@@ -117,7 +117,7 @@ class MultiReader(BaseProcess):
 
         # Set a variable here so that we can ignore file size checking when reading 
         # multiple files. This should then get handled by gap filling.
-        self._multi_read = True
+        self._skip_file_size_check = True
 
         if reader_kw is None:
             reader_kw = {}

--- a/src/skdh/io/multireader.py
+++ b/src/skdh/io/multireader.py
@@ -115,6 +115,10 @@ class MultiReader(BaseProcess):
             mode=mode, reader=reader, resample_to_lowest=resample_to_lowest, fill_gaps=fill_gaps, fill_value=fill_value, gaps_error=gaps_error
         )
 
+        # Set a variable here so that we can ignore file size checking when reading 
+        # multiple files. This should then get handled by gap filling.
+        self._multi_read = True
+
         if reader_kw is None:
             reader_kw = {}
 


### PR DESCRIPTION
Changes
---------

- Fixed issue with CSV reader where it would convert aware timestamps back to naive even when tz_name was available.
- Allow multireader to skip file size checking since any data gaps can be filled by the reader



Copilot Summary
------------------

This pull request primarily focuses on updates to the `scikit-digital-health` package. The key changes include an update to the version number in `meson.build`, the addition of a condition to skip file size checks in `base.py` and `multireader.py`, and a change in the timezone conversion logic in `csv.py`.

File Size Check Modifications:
* [`src/skdh/io/base.py`](diffhunk://#diff-13ac738240d45629cbfc92bc2e7fedaba31fda186e28f94cf47e703eb2b5f76eL61-R61): In the `wrapper_check_input_file` method, a condition has been added to skip the file size check if the `_skip_file_size_check` attribute exists.
* [`src/skdh/io/multireader.py`](diffhunk://#diff-3b4bd3be22e0adff3438a4c27a6dbfe7c13c5d941030801cadd4833e43e3b6c8R118-R121): In the `__init__` method, the `_skip_file_size_check` attribute has been added, which allows skipping the file size check when reading multiple files.

Timezone Conversion Logic Change:
* [`src/skdh/io/csv.py`](diffhunk://#diff-67f29902e1c2c8f709fac7f3cc61a94219a3b4b170cba5941e01a7b0291bb83eL327-R327): In the `predict` method, the timezone conversion logic has been altered. The timestamp data is now only converted to the specified timezone, without localizing it to a naive timestamp.