### PR TITLE
Fix documentation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-![skdh_badge](https://github.com/PfizerRD/scikit-digital-health/workflows/skdh/badge.svg)
+![skdh_badge](https://github.com/pfizer-opensource/scikit-digital-health/workflows/skdh/badge.svg)
 
 Scikit Digital Health (SKDH) is a Python package with methods for ingesting and analyzing wearable inertial sensor data.
 
 - Documentation: https://scikit-digital-health.readthedocs.io/en/latest/
-- Bug reports: https://github.com/PfizerRD/scikit-digital-health/issues
+- Bug reports: https://github.com/pfizer-opensource/scikit-digital-health/issues
 - Contributing: https://scikit-digital-health.readthedocs.io/en/latest/src/dev/contributing.html
 
 SKDH provides the following:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": f"https://github.com/PfizerRD/{project}",
+            "url": f"https://github.com/pfizer-opensource/{project}",
             "icon": "fab fa-github-square",
         },
     ],

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,10 +7,10 @@
 Scikit Digital Health
 =====================
 
-.. image:: https://github.com/PfizerRD/scikit-digital-health/workflows/skdh/badge.svg
+.. image:: https://github.com/pfizer-opensource/scikit-digital-health/workflows/skdh/badge.svg
    :alt: GitHub Actions Badge
 
-`SciKit-Digital-Health` is a Python package with methods for reading, pre-processing, manipulating, and analyzing Inertial Meausurement Unit data. `scikit-digital-health` contains the following sub-modules:
+`SciKit-Digital-Health` is a Python package with methods for reading, pre-processing, manipulating, and analyzing Inertial Measurement Unit data. `scikit-digital-health` contains the following sub-modules:
 
 .. grid:: 1 2 2 2
     :gutter: 2

--- a/docs/src/dev/contributing.rst
+++ b/docs/src/dev/contributing.rst
@@ -13,7 +13,7 @@ This is the short summary, complete descriptions are below:
 
 1. If you are contributing for the first time:
 
-    * Go to https://github.com/PfizerRD/scikit-digital-health and use the "fork" button to create a version that will create a copy for yourself.
+    * Go to https://github.com/pfizer-opensource/scikit-digital-health and use the "fork" button to create a version that will create a copy for yourself.
     * Clone the project to your local computer::
 
         git clone https://github.com/your-username/scikit-digital-health.git
@@ -24,7 +24,7 @@ This is the short summary, complete descriptions are below:
     
     * Add the upstream repository::
 
-        git remote add upstream https://github.com/PfizerRD/scikit-digital-health.git
+        git remote add upstream https://github.com/pfizer-opensource/scikit-digital-health.git
     
     * After adding the upstream repository, `git remote -v` will show two remote repositories:
 

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -22,11 +22,11 @@ Both PyPI and Conda-Forge should have pre-built wheels for major distributions.
 
         ::
 
-            pip install git+ssh://git@github.com/PfizerRD/scikit-digital-health.git
+            pip install git+ssh://git@github.com/pfizer-opensource/scikit-digital-health.git
             # install from a specific tag
-            pip install git+ssh://git@github.com/PfizerRD/scikit-digital-health@0.9.10
+            pip install git+ssh://git@github.com/pfizer-opensource/scikit-digital-health@0.9.10
             # install from a specific branch
-            pip install git+ssh://git@github.com/PfizerRD/scikit-digital-health@development
+            pip install git+ssh://git@github.com/pfizer-opensource/scikit-digital-health@development
 
 Run-time requirements
 ^^^^^^^^^^^^^^^^^^^^^
@@ -70,7 +70,7 @@ Testing the Build
 ^^^^^^^^^^^^^^^^^
 
 In order to test a build, you will need to clone or download the source code from
-`GitHub <https://github.com/PfizerRD/scikit-digital-health>`_, as the tests are isolated
+`GitHub <https://github.com/pfizer-opensource/scikit-digital-health>`_, as the tests are isolated
 from access to the package source code. Additionally, the following are requirements
 to run the test suite:
 

--- a/src/skdh/features/lib/entropy.py
+++ b/src/skdh/features/lib/entropy.py
@@ -66,8 +66,8 @@ class SignalEntropy(Feature):
         signal : array-like
             Array-like containing values to compute the signal entropy for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the signal entropy will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -132,8 +132,8 @@ class SampleEntropy(Feature):
         signal : array-like
             Array-like containing values to compute the sample entropy for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the sample entropy will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -178,10 +178,10 @@ class PermutationEntropy(Feature):
         Parameters
         ----------
         signal : array-like
-            Array-like containing values to compute the signal entropy for.
+            Array-like containing values to compute the permutation entropy for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the permutation entropy will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------

--- a/src/skdh/features/lib/extensions/ffeatures.f95
+++ b/src/skdh/features/lib/extensions/ffeatures.f95
@@ -261,7 +261,7 @@ end subroutine
 ! 
 !     Input
 !     n        : integer(long)
-!     x(n)     : real(double), array to compute signal entropy for
+!     x(n)     : real(double), array to compute dominant frequency for
 !     nfft     : integer(long), number of points to use in the FFT computation
 !     fs       : real(double), sampling frequency in Hz
 !     low_cut  : real(double), low frequency cutoff for the range to use
@@ -313,7 +313,7 @@ end subroutine
 ! 
 !     Input
 !     n        : integer(long)
-!     x(n)     : real(double), array to compute signal entropy for
+!     x(n)     : real(double), array to compute dominant frequency value for
 !     nfft     : integer(long), number of points to use in the FFT computation
 !     fs       : real(double), sampling frequency in Hz
 !     low_cut  : real(double), low frequency cutoff for the range to use
@@ -362,7 +362,7 @@ end subroutine
 ! 
 !     Input
 !     n        : integer(long)
-!     x(n)     : real(double), array to compute signal entropy for
+!     x(n)     : real(double), array to compute power spectral sum for
 !     nfft     : integer(long), number of points to use in the FFT computation
 !     fs       : real(double), sampling frequency in Hz
 !     low_cut  : real(double), low frequency cutoff for the range to use
@@ -422,7 +422,7 @@ end subroutine
 ! 
 !     Input
 !     n         : integer(long)
-!     x(n)      : real(double), array to compute signal entropy for
+!     x(n)      : real(double), array to compute the range power sum for
 !     nfft      : integer(long), number of points to use in the FFT computation
 !     fs        : real(double), sampling frequency in Hz
 !     low_cut   : real(double), low frequency cutoff for the range to use
@@ -490,7 +490,7 @@ end subroutine
 ! 
 !     Input
 !     n        : integer(long)
-!     x(n)     : real(double), array to compute signal entropy for
+!     x(n)     : real(double), array to compute spectral entropy for
 !     nfft     : integer(long), number of points to use in the FFT computation
 !     fs       : real(double), sampling frequency in Hz
 !     low_cut  : real(double), low frequency cutoff for the range to use
@@ -543,7 +543,7 @@ end subroutine
 ! 
 !     Input
 !     n        : integer(long)
-!     x(n)     : real(double), array to compute signal entropy for
+!     x(n)     : real(double), array to compute the spectral flatness for
 !     nfft     : integer(long), number of points to use in the FFT computation
 !     fs       : real(double), sampling frequency in Hz
 !     low_cut  : real(double), low frequency cutoff for the range to use

--- a/src/skdh/features/lib/frequency.py
+++ b/src/skdh/features/lib/frequency.py
@@ -65,8 +65,8 @@ class DominantFrequency(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is assumed to be 1Hz.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the dominant frequency will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -125,8 +125,8 @@ class DominantFrequencyValue(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is assumed to be 1Hz.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the dominant frequency value will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -187,8 +187,8 @@ class PowerSpectralSum(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is assumed to be 1Hz.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the power spectral sum will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -266,12 +266,12 @@ class RangePowerSum(Feature):
         Parameters
         ----------
         signal : array-like
-            Array-like containing values to compute the power spectral sum for.
+            Array-like containing values to compute the range power sum for.
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is assumed to be 1Hz.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the range power sum will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -340,8 +340,8 @@ class SpectralFlatness(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is assumed to be 1Hz.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the spectral flatness will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -401,8 +401,8 @@ class SpectralEntropy(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is assumed to be 1Hz.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the spectral entropy will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------

--- a/src/skdh/features/lib/misc.py
+++ b/src/skdh/features/lib/misc.py
@@ -39,8 +39,8 @@ class ComplexityInvariantDistance(Feature):
             Array-like containing values to compute the complexity invariant
             distance for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if
-            `signal` is a pandas.DataFrame. Default is last (-1).
+            Axis along which the complexity invariant distance will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -84,8 +84,8 @@ class RangeCountPercentage(Feature):
         signal : array-like
             Array-like containing values to compute the range count percentage for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the range count percentage will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -124,8 +124,8 @@ class RatioBeyondRSigma(Feature):
         signal : array-like
             Array-like containing values to compute the ratio beyond :math:`r\sigma` for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the ratio beyond :math:`r\sigma` will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------

--- a/src/skdh/features/lib/moments.py
+++ b/src/skdh/features/lib/moments.py
@@ -43,8 +43,8 @@ class Mean(Feature):
         signal : array-like
             Array-like containing values to compute the mean for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the mean will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -76,8 +76,8 @@ class MeanCrossRate(Feature):
         signal : array-like
             Array-like containing values to compute the mean cross rate for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the mean cross rate will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -120,8 +120,8 @@ class StdDev(Feature):
         signal : array-like
             Array-like containing values to compute the standard deviation for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the standard deviation will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -153,8 +153,8 @@ class Skewness(Feature):
         signal : array-like
             Array-like containing values to compute the skewness for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the skewness will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -186,8 +186,8 @@ class Kurtosis(Feature):
         signal : array-like
             Array-like containing values to compute the kurtosis for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the kurtosis will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------

--- a/src/skdh/features/lib/smoothness.py
+++ b/src/skdh/features/lib/smoothness.py
@@ -50,8 +50,8 @@ class JerkMetric(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is 1.0Hz
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if
-            `signal` is a pandas.DataFrame. Default is last (-1).
+            Axis along which the jerk metric will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -138,8 +138,8 @@ class DimensionlessJerk(Feature):
             Array-like containing values to compute the dimensionless jerk
             metric for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if
-            `signal` is a pandas.DataFrame. Default is last (-1).
+            Axis along which the dimensionless jerk metric will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -206,8 +206,8 @@ class SPARC(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is 1.0Hz
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if
-            `signal` is a pandas.DataFrame. Default is last (-1).
+            Axis along which the SPARC will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------

--- a/src/skdh/features/lib/statistics.py
+++ b/src/skdh/features/lib/statistics.py
@@ -34,8 +34,8 @@ class Range(Feature):
         signal : array-like
             Array-like containing values to compute the range for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the range will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -67,8 +67,8 @@ class IQR(Feature):
         signal : array-like
             Array-like containing values to compute the IQR for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the IQR will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -100,8 +100,8 @@ class RMS(Feature):
         signal : array-like
             Array-like containing values to compute the RMS for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the RMS will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -143,8 +143,8 @@ class Autocorrelation(Feature):
         signal : array-like
             Array-like containing values to compute the autocorrelation for.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the autocorrelation will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -176,8 +176,8 @@ class LinearSlope(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is 1.0Hz.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the linear slope will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------

--- a/src/skdh/features/lib/wavelet.py
+++ b/src/skdh/features/lib/wavelet.py
@@ -58,8 +58,8 @@ class DetailPower(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is 1.0Hz.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if
-            `signal` is a pandas.DataFrame. Default is last (-1).
+            Axis along which the detail power will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------
@@ -151,8 +151,8 @@ class DetailPowerRatio(Feature):
         fs : float, optional
             Sampling frequency in Hz. If not provided, default is 1.0Hz.
         axis : int, optional
-            Axis along which the signal entropy will be computed. Ignored if `signal` is a
-            pandas.DataFrame. Default is last (-1).
+            Axis along which the detail power ratio will be computed.
+            Ignored if `signal` is a pandas.DataFrame. Default is last (-1).
 
         Returns
         -------


### PR DESCRIPTION
This PR fixes some inconsistencies in docs:
- For all features, the `axis=` keyword for the `compute()` method was probably copied over from `SignalEntropy`, and the feature name stuck. Also in the Fortran code.
- As I see the `PfizerRD` GitHub org migrated its name to `pfizer-opensource`. Despite the old address still works, I think it's useful if it doesn't create any ambiguity.